### PR TITLE
Changed missing em-4.0.15-lt.tar.bz2 file to .gz

### DIFF
--- a/package/uemacs/uemacs.mk
+++ b/package/uemacs/uemacs.mk
@@ -5,7 +5,7 @@
 #############################################################
 
 UEMACS_VERSION = 4.0.15-lt
-UEMACS_SOURCE = em-$(UEMACS_VERSION).tar.bz2
+UEMACS_SOURCE = em-$(UEMACS_VERSION).tar.gz
 UEMACS_SITE = $(BR2_KERNEL_MIRROR)/software/editors/uemacs/
 UEMACS_DEPENDENCIES = ncurses
 


### PR DESCRIPTION
According to archive.org, the .bz2 file has disappeared a long time ago. 

Why was this even working? Perhaps kernel.org is load balanced between several mirrors and some kept the old file?

http://web.archive.org/web/20120108070832/http://www.kernel.org/pub/linux/kernel/uemacs/
http://web.archive.org/web/20110827075051/http://www.kernel.org/pub/linux/kernel/uemacs/